### PR TITLE
Use "0" as default argument for page_from parameter

### DIFF
--- a/pypisearch/search.py
+++ b/pypisearch/search.py
@@ -15,7 +15,7 @@ class Search:
     def __init__(
         self,
         query: str,
-        page_from: str = "",
+        page_from: str = "0",
         page_to: Optional[str] = None,
     ) -> None:
         page_from, page_to = int(page_from), int(page_to) if page_to else None


### PR DESCRIPTION
Using "" as default argument breaks backward compatibility: anyone using the old constructor signature (Search(query) without page-related argument) will have an error because "" is not convertible to an int using the int() function. Using "0" instead seems to be a good alternative to keep backward compatibility.